### PR TITLE
Updatexxx io.arrow-kt:arrow-data to 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog
 * Bugfix: BehaviorSpec doesn't allow config bug #495
 * Bugfix: Error when throwing AssertionError from inside a shouldThrow{} block #479
 * Bugfix: Fix test timeouts #476
+* Bugfix: Fix annotation spec failure message #539
 * Internal: Build now uses Kotlin 1.3 #379
 * Internal: Upgraded class scanning to use ClassGraph instead of Reflections #459
 

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/AbstractProjectConfig.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/AbstractProjectConfig.kt
@@ -57,6 +57,14 @@ abstract class AbstractProjectConfig {
   open fun parallelism(): Int = 1
 
   /**
+   * When set to true, failed specs are written to a file called spec_failures.
+   * This file is used on subsequent test runs to run the failed specs first.
+   * To disable this feature, set this to false, or set the system property
+   * 'kotlintest.write.specfailures=false'
+   */
+  open fun writeSpecFailureFile(): Boolean = true
+
+  /**
    * Sets the order of top level tests in a spec.
    * The value set here will be used unless overriden in a [Spec].
    * The value in a [Spec] is always taken in preference to the value here.

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/Project.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/Project.kt
@@ -38,13 +38,14 @@ object Project {
 
   private fun discoverProjectConfig(): AbstractProjectConfig? {
     return try {
-      val projectConfigFullyQualifiedName = System.getProperty("kotlintest.project.config") ?: defaultProjectConfigFullyQualifiedName
+      val projectConfigFullyQualifiedName = System.getProperty("kotlintest.project.config")
+          ?: defaultProjectConfigFullyQualifiedName
       val clas = Class.forName(projectConfigFullyQualifiedName)
       val field = clas.declaredFields.find { it.name == "INSTANCE" }
       when (field) {
-      // if the static field for an object cannot be found, then instantiate
+        // if the static field for an object cannot be found, then instantiate
         null -> clas.newInstance() as AbstractProjectConfig
-      // if the static field can be found then use it
+        // if the static field can be found then use it
         else -> field.get(null) as AbstractProjectConfig
       }
     } catch (cnf: ClassNotFoundException) {
@@ -56,6 +57,7 @@ object Project {
   private val _listeners = mutableListOf<TestListener>()
   private val _filters = mutableListOf<ProjectLevelFilter>()
   private var _specExecutionOrder: SpecExecutionOrder = LexicographicSpecExecutionOrder
+  private var writeSpecFailureFile: Boolean = true
 
   private var parallelism: Int = 1
 
@@ -82,8 +84,10 @@ object Project {
     _filters.addAll(this.filters())
     _specExecutionOrder = this.specExecutionOrder()
     parallelism = System.getProperty("kotlintest.parallelism")?.toInt() ?: this.parallelism()
+    writeSpecFailureFile = System.getProperty("kotlintest.write.specfailures") == "true" || this.writeSpecFailureFile()
   }
 
+  fun writeSpecFailureFile(): Boolean = writeSpecFailureFile
   fun specExecutionOrder(): SpecExecutionOrder = _specExecutionOrder
 
   fun beforeAll() {


### PR DESCRIPTION
Updates io.arrow-kt:arrow-data to 0.8.2.

If you'd like to skip this version, you can just close this PR.

Be well.